### PR TITLE
feat: http interceptor

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { provideHttpClient } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { ErrorStateMatcher, provideNativeDateAdapter, ShowOnDirtyErrorStateMatcher } from '@angular/material/core';
 import { MAT_DIALOG_DEFAULT_OPTIONS } from '@angular/material/dialog';
@@ -10,17 +10,18 @@ import { keepPreviousData, provideTanStackQuery, QueryClient } from '@tanstack/a
 import { ClientStorageService } from '@common/services/client-storage.service.abstract';
 import { LocalStorageService } from '@common/services/local-storage.service';
 import { routes } from './app.routes';
+import { AuthInterceptor } from '@common/interceptors/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideAnimationsAsync(),
-    provideHttpClient(),
+    provideHttpClient(withInterceptorsFromDi()),
     provideTanStackQuery(
       new QueryClient({
         defaultOptions: {
           queries: {
             placeholderData: keepPreviousData,
-            staleTime: Infinity
+            staleTime: Infinity,
           },
         },
       })
@@ -35,5 +36,10 @@ export const appConfig: ApplicationConfig = {
     },
     { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline', subscriptSizing: 'dynamic' } },
     { provide: ClientStorageService, useClass: LocalStorageService },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: AuthInterceptor,
+      multi: true,
+    },
   ],
 };

--- a/src/app/common/interceptors/auth.interceptor.ts
+++ b/src/app/common/interceptors/auth.interceptor.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  private readonly EXCLUDED_BEARER_ROUTES = ['/auth'];
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const accessToken = this.getAccessToken();
+
+    if (!accessToken) return next.handle(req);
+    if (this.shouldExcludeBearerRoute(req.url)) return next.handle(req);
+
+    const authReq = req.clone({
+      setHeaders: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    return next.handle(authReq);
+  }
+
+  private shouldExcludeBearerRoute(url: string): boolean {
+    return this.EXCLUDED_BEARER_ROUTES.some((route) => url.includes(route));
+  }
+
+  private getAccessToken(): string | null {
+    return localStorage.getItem('accessToken');
+  }
+}

--- a/src/app/common/interceptors/auth.interceptor.ts
+++ b/src/app/common/interceptors/auth.interceptor.ts
@@ -22,6 +22,6 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 
   private shouldExcludeBearerRoute(url: string): boolean {
-    return this._EXCLUDED_BEARER_ROUTES.some((route) => url.includes(route));
+    return this._EXCLUDED_BEARER_ROUTES.some((route) => url.startsWith(route));
   }
 }

--- a/src/app/common/interceptors/auth.interceptor.ts
+++ b/src/app/common/interceptors/auth.interceptor.ts
@@ -1,16 +1,18 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { AuthService } from '@auth/auth.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
-  private readonly EXCLUDED_BEARER_ROUTES = ['/auth'];
+  private readonly _EXCLUDED_BEARER_ROUTES = ['/auth'];
+  private readonly _authService = inject(AuthService);
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    const accessToken = this.getAccessToken();
-
-    if (!accessToken) return next.handle(req);
     if (this.shouldExcludeBearerRoute(req.url)) return next.handle(req);
+
+    const accessToken = this._authService.accessToken();
+    if (!accessToken) return next.handle(req);
 
     const authReq = req.clone({
       setHeaders: { Authorization: `Bearer ${accessToken}` },
@@ -20,10 +22,6 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 
   private shouldExcludeBearerRoute(url: string): boolean {
-    return this.EXCLUDED_BEARER_ROUTES.some((route) => url.includes(route));
-  }
-
-  private getAccessToken(): string | null {
-    return localStorage.getItem('accessToken');
+    return this._EXCLUDED_BEARER_ROUTES.some((route) => url.includes(route));
   }
 }


### PR DESCRIPTION
## Descripción

Se agregó un interceptor HTTP que agrega el encabezado `Authorization` con el JWT extraído del `AuthService`. Este interceptor actúa sobre todas las requests enviadas al backend excluyendo las de autenticación (que son públicas). Además de la creación de la clase, se realizaron cambios en la configuración del `HttpClient` para que incorpore los interceptors declarados como inyectables en la aplicación (`withInterceptorsFromDi()`).